### PR TITLE
Bug redirectonbadtour

### DIFF
--- a/app/components/CreateTour.jsx
+++ b/app/components/CreateTour.jsx
@@ -39,7 +39,7 @@ export default class CreateTour extends React.Component {
     .then(tour => {
       return this.props.getCurrTour(tour.id).then(_tour => {
         this.props.appendTour(_tour);
-        return tour;
+        return _tour;
       });
     })
     .then(tour => {

--- a/app/components/CreateTour.jsx
+++ b/app/components/CreateTour.jsx
@@ -39,6 +39,7 @@ export default class CreateTour extends React.Component {
     .then(tour => {
       return this.props.getCurrTour(tour.id).then(_tour => {
         this.props.appendTour(_tour);
+        return tour;
       });
     })
     .then(tour => {

--- a/app/components/MapMap.jsx
+++ b/app/components/MapMap.jsx
@@ -90,6 +90,7 @@ export default class MapMap extends React.Component {
   renderSingleTour(tour, retry) {
     const retries = retry || 0;
     const DirectionsService = new google.maps.DirectionsService();
+    if (!tour || !tour.sites) return this.context.router.transitionTo('nearby');
     const route = tour.sites.map((siteObj) => {
       const {latitude, longitude} = siteObj.coords;
       return {


### PR DESCRIPTION
Catches the case if use goes directly to tour map (or if tour or tour.sites is undefined for some other reason) and redirects to 'nearby'.
